### PR TITLE
Started work on support for weighted hypernetworks

### DIFF
--- a/hypernetx/classes/entity.py
+++ b/hypernetx/classes/entity.py
@@ -939,7 +939,7 @@ class EntitySet(Entity):
         ndict = dict(zip(self.children,range(nchildren)))
         edict = dict(zip(self.uidset,range(nuidset)))
 
-        if len(ndict) is not 0:
+        if len(ndict) != 0:
             
             if index:
                 rowdict = {v:k for k,v in ndict.items()}

--- a/hypernetx/classes/hypergraph.py
+++ b/hypernetx/classes/hypergraph.py
@@ -449,7 +449,7 @@ class Hypergraph():
 				else:
 					self._nodes.add(Entity(node)) 
 
-	def add_edge(self,edge):
+	def add_edge(self, edge, **kwargs):
 		"""
 		Adds a single edge to hypergraph.
 
@@ -457,6 +457,8 @@ class Hypergraph():
 		----------
 		edge : hashable or Entity
 			If hashable the edge returned will be empty.
+		kwargs : keyword arguments, optional
+            Edge data can be assigned using keyword arguments.
 
 		Returns
 		-------
@@ -477,6 +479,11 @@ class Hypergraph():
 		elif edge in self._nodes:
 			warnings.warn("Cannot add edge. Edge is already a Node")
 		elif isinstance(edge,Entity):
+			if len(kwargs) > 0:
+				warnings.warn(
+					("Additional parameters provided "+
+					"will be ignored as edge is an Entity.")
+				)
 			if len(edge) > 0:
 				self._add_nodes_from(edge.elements.values())
 				self._edges.add(Entity(edge.uid,
@@ -486,10 +493,13 @@ class Hypergraph():
 			else:
 				self._edges.add(Entity(edge.uid, **edge.properties))		
 		else:
-			self._edges.add(Entity(edge))  ### this generates an empty edge
+			self._add_nodes_from(edge)
+			self._edges.add(Entity(edge, **kwargs))  ### this generates an empty edge
+			for node in edge:
+				self.add_node_to_edge(node, edge)
 		return self
 
-	def add_edges_from(self,edge_set):
+	def add_edges_from(self, edge_set, **kwargs):
 		"""
 		Add edges to hypergraph.
 
@@ -497,6 +507,9 @@ class Hypergraph():
 		----------
 		edge_set : iterable of hashables or Entities
 			For hashables the edges returned will be empty.
+		kwargs : keyword arguments, optional
+            Edge data (the same for all edges in edge_set
+			can be assigned using keyword arguments.
 
 		Returns
 		-------
@@ -504,7 +517,7 @@ class Hypergraph():
 
 		"""
 		for edge in edge_set:
-			self.add_edge(edge)
+			self.add_edge(edge, **kwargs)
 		return self
 
 

--- a/hypernetx/classes/hypergraph.py
+++ b/hypernetx/classes/hypergraph.py
@@ -661,6 +661,22 @@ class Hypergraph():
 
 	def __weighted_incidence_matrix(self, weight, index):
 	
+		"""
+		Helper method to calculate the weighted incidence matrix M * sqrt(W)
+		
+		Parameters
+		----------
+		index: boolean
+			if True, will return a rowdict of row to node uid	
+
+		weight: str, the name of an element in the edge dict to 
+			use as weight in the adjacency matrix calculation
+		
+		Returns
+		----------
+		adjacency_matrix : scipy.sparse.csr.csr_matrix
+		"""
+	
 		# this will be a bottleneck in big graphs
 		weight_vec = [np.sqrt(self.edges.elements[ii].__dict__[weight]) for ii in self.edges.elements]
 		return self.incidence_matrix(index=index).dot(sparse.csr_matrix(np.diag(weight_vec)))


### PR DESCRIPTION
Here is a new PR for the weighted hypernetworks code, with all the new commits in a separate branch. Here is the original comment for reference: 

I thought I would try to make it a bit easier to create a weighted hypergraph, using a similar syntax to that in networkx.  Now you can add weighted edges like this: 
```python
w = 0.019281
G = hnx.Hypergraph()
G.add_edge(("A", "B"), weight=w)
```

I've also added support for calculating the weighted ~~node~~ adjacency matrices:

```python
w0 = 0.98279384
w1 = 0.2309
G = hnx.Hypergraph()
e0 = [("A", "B"), ("B", "C")]
e1 = [("A", "B", "C")]
G.add_edges_from(e0, weight=w0)
G.add_edges_from(e1, weight=w1)
	
print(G.adjacency_matrix())
print(G.adjacency_matrix(weight="weight"))
print(G.edge_adjacency_matrix(weight="weight"))
```

~~I have an issue with the edge adjacency matrix, because I would ordinarily calculate it with the following matrix formula:  \sqrt(W) * M^T * M * \sqrt(W), but this won't currently work as ```edge_adjacency_matrix``` calls ```__incidence_to_adjacency```, the same method as is called by ```adjacency_matrix```. I would be grateful for your thoughts on this, I've currently left the weighted edge adjacency to throw a ```NotImplementedError```.~~

I have modified the code to do what I commented in the original PR. When the weighted adjacency matrix is requested, ```M.dot(weight_matrix)``` is passed into ```__incidence_to_adjacency``` so both adjacency matrix functions work.

All of these changes play quite nicely with the existing code, but I wanted to submit them for your consideration before doing too much more.

Many thanks. :) 