### PR TITLE
fixed bug in add node to edge of hypergraph

### DIFF
--- a/hypernetx/classes/hypergraph.py
+++ b/hypernetx/classes/hypergraph.py
@@ -532,9 +532,7 @@ class Hypergraph():
             if not isinstance(edge,Entity):
                 edge = self._edges[edge]
             if node in self._nodes:
-                if not isinstance(node,Entity):
-                    node = self._nodes[node]
-                self._edges[edge].add(node)
+                self._edges[edge].add(self._nodes[node])
             else:
                 if not isinstance(node,Entity):
                     node = Entity(node)


### PR DESCRIPTION
Fixed bug in Hypergraph.add_node_to_edge. Hypergraph clones nodes when they are added. Adding the same node entity adds two distinct clones. This behavior has been changed to give expected behavior, only one clone per added node is made.