### PR TITLE
Develop

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@ import sys
 import os
 import shlex
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/hypernetx/algorithms/s_centrality_measures.py
+++ b/hypernetx/algorithms/s_centrality_measures.py
@@ -112,7 +112,6 @@ def _s_centrality(
                 A, Adict = h.edge_adjacency_matrix(s=s, index=True)
             else:
                 A, Adict = h.adjacency_matrix(s=s, index=True)
-            # A = (A >= s) * 1
             g = nx.from_scipy_sparse_matrix(A)
             stats.update({Adict[k]: v for k, v in func(g, **kwargs).items()})
             if f:

--- a/hypernetx/algorithms/s_centrality_measures.py
+++ b/hypernetx/algorithms/s_centrality_measures.py
@@ -112,7 +112,7 @@ def _s_centrality(
                 A, Adict = h.edge_adjacency_matrix(s=s, index=True)
             else:
                 A, Adict = h.adjacency_matrix(s=s, index=True)
-            A = (A >= s) * 1
+            # A = (A >= s) * 1
             g = nx.from_scipy_sparse_matrix(A)
             stats.update({Adict[k]: v for k, v in func(g, **kwargs).items()})
             if f:

--- a/hypernetx/classes/hypergraph.py
+++ b/hypernetx/classes/hypergraph.py
@@ -102,9 +102,9 @@ class Hypergraph:
     static : boolean, optional, default: False
         If True the hypergraph will be immutable, edges and nodes may not be changed.
     weights : array-like, optional, default : None
-        User specified weights corresponding to setsytem of type pandas.DataFrame,
+        User specified cell weights corresponding to setsytem of type pandas.DataFrame,
         length must equal number of rows in dataframe.
-        If None, weight for all rows is assumed to be 1.
+        If None, cell weights are assumed to be 1.
     keep_weights : bool, optional, default : True
         Whether or not to use existing weights when input is StaticEntity, or StaticEntitySet.
     aggregateby : str, optional, {'count', 'sum', 'mean', 'median', max', 'min', 'first','last', None}, default : 'count'
@@ -117,8 +117,6 @@ class Hypergraph:
     filepath : str, optional, default : None
 
     """
-
-    # TODO: remove lambda functions from constructor in H and E.
 
     def __init__(
         self,

--- a/hypernetx/classes/staticentity.py
+++ b/hypernetx/classes/staticentity.py
@@ -77,8 +77,8 @@ class StaticEntity(object):
                 self.__dict__.update(props)
                 self._data = entity._data.copy()
                 if keep_weights:
-                    self._weights = entity._weights
-                    self._cell_weights = dict(entity._cell_weights)
+                    self._weights = entity._weights  # list of weights ordered on data
+                    self._cell_weights = dict(entity._cell_weights)  # dict keyed by data tuple
                 else:
                     self._data, self._cell_weights = remove_row_duplicates(
                         entity.data, weights=weights, aggregateby=aggregateby
@@ -425,7 +425,7 @@ class StaticEntity(object):
     @property
     def elements(self):
         """
-        Keys and values in the order of insertion
+        Keys and values in the order of insertion. Once computed persists for self.
 
         Returns
         -------
@@ -457,8 +457,6 @@ class StaticEntity(object):
         try:
             return dict(self._memberships)
         except:
-            # self._memberships = reverse_dictionary(self.elements)
-            # return self._memberships
             if len(self._keys) == 1:
                 return None
             else:

--- a/hypernetx/classes/staticentity.py
+++ b/hypernetx/classes/staticentity.py
@@ -64,7 +64,7 @@ class StaticEntity(object):
         uid=None,
         weights=None,
         keep_weights=True,
-        aggregateby="count",
+        aggregateby="sum",
         **props,
     ):
         self._uid = uid
@@ -77,8 +77,8 @@ class StaticEntity(object):
                 self.__dict__.update(props)
                 self._data = entity._data.copy()
                 if keep_weights:
-                    self._weights = entity._weights  # list of weights ordered on data
-                    self._cell_weights = dict(entity._cell_weights)  # dict keyed by data tuple
+                    self._weights = entity._weights
+                    self._cell_weights = dict(entity._cell_weights)
                 else:
                     self._data, self._cell_weights = remove_row_duplicates(
                         entity.data, weights=weights, aggregateby=aggregateby
@@ -425,7 +425,7 @@ class StaticEntity(object):
     @property
     def elements(self):
         """
-        Keys and values in the order of insertion. Once computed persists for self.
+        Keys and values in the order of insertion
 
         Returns
         -------
@@ -457,6 +457,8 @@ class StaticEntity(object):
         try:
             return dict(self._memberships)
         except:
+            # self._memberships = reverse_dictionary(self.elements)
+            # return self._memberships
             if len(self._keys) == 1:
                 return None
             else:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 import sys
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 if sys.version_info < (3, 7):
     sys.exit("HyperNetX requires Python 3.7 or later.")


### PR DESCRIPTION
Bugfix for adjacency matrix.  Cell weighting is currently only supported for incidence matrices. User will need to determine appropriate use of weights for adjacency matrix according to their application for now.
Static nodes and edges can have attributes set through the StaticEntity class. Use s-parameter to generate s-linegraph adjacency matrix and networkx generated graph with node and edge attributes read from data.