### PR TITLE
Support for NetworkX>3.0?

### DIFF
--- a/hypernetx/classes/hypergraph.py
+++ b/hypernetx/classes/hypergraph.py
@@ -1880,7 +1880,7 @@ class Hypergraph:
         list of the s-component nodes
         """
         A, coldict = self.adjacency_matrix(s=s, index=True)
-        G = nx.from_scipy_sparse_matrix(A)
+        G = nx.from_scipy_sparse_array(A)
         diams = []
         comps = []
         for c in nx.connected_components(G):
@@ -1914,7 +1914,7 @@ class Hypergraph:
 
         """
         A, coldict = self.edge_adjacency_matrix(s=s, index=True)
-        G = nx.from_scipy_sparse_matrix(A)
+        G = nx.from_scipy_sparse_array(A)
         diams = []
         comps = []
         for c in nx.connected_components(G):
@@ -1955,7 +1955,7 @@ class Hypergraph:
 
         """
         A = self.adjacency_matrix(s=s)
-        G = nx.from_scipy_sparse_matrix(A)
+        G = nx.from_scipy_sparse_array(A)
         if nx.is_connected(G):
             return nx.diameter(G)
 
@@ -1989,7 +1989,7 @@ class Hypergraph:
 
         """
         A = self.edge_adjacency_matrix(s=s)
-        G = nx.from_scipy_sparse_matrix(A)
+        G = nx.from_scipy_sparse_array(A)
         if nx.is_connected(G):
             return nx.diameter(G)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ packages =
 	hypernetx.utils
 	hypernetx.utils.toys
 install_requires =
-	networkx>=2.2,<3.0
+	networkx>=2.2,<4.0
 	numpy>=1.24.0,<2.0
 	scipy>=1.1.0,<2.0
 	matplotlib>3.0


### PR DESCRIPTION
After updating the deprecated adjacency matrix to graph function (mentioned in https://github.com/pnnl/HyperNetX/issues/146) all tests seem to pass when using NetworkX 3.2. 

Are there any other reasons for the conservative <3.0 dependency? Can this be updated? 